### PR TITLE
Corrected indentation on For statement

### DIFF
--- a/print_s.c
+++ b/print_s.c
@@ -19,5 +19,6 @@ int print_s(va_list s)
 	
 	for (i = 0 ; str[i] != '\0'; i++)
 		_putchar(str[i]);
+
 		return (i);
 }


### PR DESCRIPTION
Indentation was causing an error with the compiler on the For loop, should be corrected now. 